### PR TITLE
Fix aggregation issue

### DIFF
--- a/covid-forecasting.py
+++ b/covid-forecasting.py
@@ -36,9 +36,9 @@ def improve_data(world,spain):
     spain.columns=list(spain.columns[:2])+[dt.datetime.strptime(date,"%Y-%m-%d").strftime("%d/%m/%Y") for date in spain.columns[2:]]
     
     
-    selected_countries=list(world.loc[world['Province/State']!='All','Country/Region'].sort_values().unique())
+    countries=list(world['Country/Region'].sort_values().unique())
     
-    for country in selected_countries:
+    for country in countries:
         if len(world.loc[world['Country/Region']==country,'Province/State'].sort_values().unique()) == 1:
             world.loc[world['Country/Region']==country,'Province/State']=world.loc[world['Country/Region']==country,'Province/State'].fillna('All')
         else:

--- a/covid-forecasting.py
+++ b/covid-forecasting.py
@@ -36,14 +36,17 @@ def improve_data(world,spain):
     spain.columns=list(spain.columns[:2])+[dt.datetime.strptime(date,"%Y-%m-%d").strftime("%d/%m/%Y") for date in spain.columns[2:]]
     
     
-    world['Province/State']=world['Province/State'].fillna('All')
     selected_countries=list(world.loc[world['Province/State']!='All','Country/Region'].sort_values().unique())
     
     for country in selected_countries:
-        all_data=pd.DataFrame(world[world['Country/Region']==country].iloc[:,5:].sum()).T
-        all_data['Province/State']='All'
-        all_data['Country/Region']=country
-        world=pd.concat([world,all_data],axis=0)
+        if len(world.loc[world['Country/Region']==country,'Province/State'].sort_values().unique()) == 1:
+            world.loc[world['Country/Region']==country,'Province/State']=world.loc[world['Country/Region']==country,'Province/State'].fillna('All')
+        else:
+            world.loc[world['Country/Region']==country,'Province/State']=world.loc[world['Country/Region']==country,'Province/State'].fillna('Other')
+            all_data=pd.DataFrame(world[world['Country/Region']==country].iloc[:,5:].sum()).T
+            all_data['Province/State']='All'
+            all_data['Country/Region']=country
+            world=pd.concat([world,all_data],axis=0)
         
     
     spain=spain.rename(columns={'CCAA':'Province/State'}).drop('cod_ine',axis=1)[:19]


### PR DESCRIPTION
When selecting Denmark, I get the following error:

```!python
ValueError: Length mismatch: Expected axis has 6 elements, new values have 3 elements
Traceback:
  File "/app/.heroku/python/lib/python3.6/site-packages/streamlit/ScriptRunner.py", line 324, in _run_script
    exec(code, module.__dict__)
  File "/app/covid-forecasting.py", line 207, in <module>
    df=separate_region(country,region)
  File "/app/covid-forecasting.py", line 65, in separate_region
    data.columns=['Confirmed','Deaths','Recovered']
  File "/app/.heroku/python/lib/python3.6/site-packages/pandas/core/generic.py", line 5192, in __setattr__
    return object.__setattr__(self, name, value)
  File "pandas/_libs/properties.pyx", line 67, in pandas._libs.properties.AxisProperty.__set__
  File "/app/.heroku/python/lib/python3.6/site-packages/pandas/core/generic.py", line 690, in _set_axis
    self._data.set_axis(axis, labels)
  File "/app/.heroku/python/lib/python3.6/site-packages/pandas/core/internals/managers.py", line 183, in set_axis
    "values have {new} elements".format(old=old_len, new=new_len)
```

This is because the data for Denmark contains two named groups and an unnamed group.

The unnamed groups would be renamed to "All" but as Denmark matches the `selected_countries`, a second "All" is added.

My change will rename the group to "Other" for countries with other provinces/states.

I haven't written Python for many years and don't know the libraries used so please feel free to close this if there's a better solution.